### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
+    @items = Item.all.order(id: 'DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all.order(id: 'DESC')
+    @items = Item.order(id: 'DESC')
   end
 
   def new

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,25 @@
+<li class='list'>
+  <%= link_to "#" do %>
+    <div class='item-img-content'>
+      <%= image_tag item.image, class: "item-img" %>
+      <%# 商品が売れていればsold outを表示しましょう %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れていればsold outを表示しましょう %>
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+        <%= item.name %>
+      </h3>
+      <div class='item-price'>
+        <span><%= item.price %>円<br>
+          <%= item.shipping_fee.name %></span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
     </div>
     <ul class='item-lists'>
       <%= render partial: 'item', collection: @items %>
-      <% if @items == nil %>
+      <% if @items == [] %>
         <%# 商品がない場合のダミー %>
         <li class='list'>
           <%= link_to '#' do %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -122,60 +122,34 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
-            </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= "商品名" %>
-            </h3>
-            <div class='item-price'>
-              <span><%= "販売価格" %>円<br>
-                <%= '配送料負担' %></span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
+      <%= render partial: 'item', collection: @items %>
+      <% if @items == nil %>
+        <%# 商品がない場合のダミー %>
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>
+                  (税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
               </div>
             </div>
-          </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              商品を出品してね！
-            </h3>
-            <div class='item-price'>
-              <span>99999999円<br>
-                (税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+        <%# //商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
-<%= link_to('#', class: 'purchase-btn') do %>
+<%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Item, type: :model do
       it 'item should belong to user' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
     end
   end


### PR DESCRIPTION
# what
商品一覧表示機能の実装

# why
トップページで種品されている商品を一覧で確認できるようにするため

# 作業内容
- items/indexコントローラの編集
- 'index.html.erb'から、商品の表示を部分テンプレートとして'_item.html.erb'に書き出し

# gyazo
- 商品データがない場合はダミーが表示される
https://gyazo.com/52a74b1a0b9abd1da1ad4077116aaa8b
- 商品データがある場合は出品日時が新しい順で一覧表示される
https://gyazo.com/3dcc5790a5e8a0866a0db4ca3f6fe5da